### PR TITLE
Fix some overlaps on Spy frame

### DIFF
--- a/ElvUI_ProjectHopes/Core/Modules/Border/Addons/Spy.lua
+++ b/ElvUI_ProjectHopes/Core/Modules/Border/Addons/Spy.lua
@@ -1,58 +1,74 @@
 local Name, Private = ...
 local E, L, V, P, G = unpack(ElvUI)
 local BORDER = E:GetModule('BORDER')
-
 local S = E:GetModule('Skins')
 
 local _G = _G
-local hooksecurefunc = hooksecurefunc
 local pairs = pairs
-local type = type
-local unpack = unpack
 
 function S:Spy()
-	if not E.db.ProjectHopes.skins.spy then
-		return
-	end
+	if not E.db.ProjectHopes.skins.spy then return end
 
-	local Spy_MainWindow = _G.Spy_MainWindow
-	S:HandleFrame(Spy_MainWindow)
-	BORDER:CreateBorder(Spy_MainWindow)
-	local Spy_AlertWindow = _G.Spy_AlertWindow
-	S:HandleFrame(Spy_AlertWindow)
-	BORDER:CreateBorder(Spy_AlertWindow)
-	local Icon = Spy_AlertWindow.Icon
-	Icon:CreateBackdrop()
-	BORDER:CreateBorder(Icon)
-	local SpyStatsFrame = _G.SpyStatsFrame
-	S:HandlePortraitFrame(SpyStatsFrame)
-	SpyStatsFrame.StatsFrame:StripTextures()
-	SpyStatsFrame.StatsFrame:SetTemplate('Transparent')
-	BORDER:CreateBorder(SpyStatsFrame)
-	_G.SpyStatsTabFrameTabContentFrame:StripTextures()
-	_G.SpyStatsTabFrameTabContentFrame:SetTemplate('Transparent')
-	S:HandleCloseButton(SpyStatsFrameTopCloseButton)
-	BORDER:CreateBorder(_G.SpyStatsTabFrameTabContentFrame)
-	SpyStatsFrame_Title:ClearAllPoints()
-	SpyStatsFrame_Title:SetPoint("TOP", SpyStatsFrame, "TOP", 0, -15)
+	local frameData = {
+    	{frame = _G.Spy_MainWindow},
+		{frame = _G.Spy_AlertWindow},
+		{frame = _G.SpyStatsFrame.StatsFrame, scrollbar = _G.SpyStatsTabFrameTabContentFrameScrollFrameScrollBar},
+		{frame = _G.SpyStatsPlayerHistoryFrame},
+		{frame = _G.SpyStatsTabFrameTabContentFrame},
+		{frame = _G.SpyStatsTabFrameTabContentFrame.ContentFrame},
+	}
+
+	local editboxData = {
+		{editbox = _G.SpyStatsFilterBox.FilterBox, borderParams = {nil, nil, nil, nil, nil, true, false}},
+	}
+
+	local buttonData = {
+		{button = _G.SpyStatsRefreshButton, borderParams = {nil, nil, nil, nil, nil, false, true}},
+	}
+
+	local checkboxData = {
+		{checkbox = _G.SpyStatsKosCheckbox, borderParams = {nil, nil, nil, nil, nil, true, true}},
+		{checkbox = _G.SpyStatsRealmCheckbox, borderParams = {nil, nil, nil, nil, nil, true, true}},
+		{checkbox = _G.SpyStatsWinsLosesCheckbox, borderParams = {nil, nil, nil, nil, nil, true, true}},
+		{checkbox = _G.SpyStatsReasonCheckbox, borderParams = {nil, nil, nil, nil, nil, true, true}},
+	}
+	-- Need this before skinning
 	_G.SpyStatsFilterBox.FilterBox:StripTextures()
-	S:HandleEditBox(_G.SpyStatsFilterBox.FilterBox)
-	_G.SpyStatsFilterBox:SetSize(150, 15)
-	BORDER:CreateBorder(_G.SpyStatsFilterBox.FilterBox)
-	S:HandleCheckBox(_G.SpyStatsKosCheckbox)
-	BORDER:CreateBorder(_G.SpyStatsKosCheckbox, nil, nil, nil, nil, nil, true, true)
-	S:HandleCheckBox(_G.SpyStatsRealmCheckbox)
-	BORDER:CreateBorder(_G.SpyStatsRealmCheckbox, nil, nil, nil, nil, nil, true, true)
-	S:HandleCheckBox(_G.SpyStatsWinsLosesCheckbox)
-	BORDER:CreateBorder(_G.SpyStatsWinsLosesCheckbox, nil, nil, nil, nil, nil, true, true)
-	S:HandleCheckBox(_G.SpyStatsReasonCheckbox)
-	BORDER:CreateBorder(_G.SpyStatsReasonCheckbox, nil, nil, nil, nil, nil, true, true)
-	S:HandleButton(_G.SpyStatsRefreshButton)
-	_G.SpyStatsRefreshButton:ClearAllPoints()
-	_G.SpyStatsRefreshButton:SetPoint("BOTTOMRIGHT", SpyStatsFrame, "BOTTOMRIGHT", -12, 5)
+
+	-- Apply the skinning
+	BORDER:SkinFrameList(frameData)
+	BORDER:SkinEditboxList(editboxData)
+	BORDER:SkinButtonList(buttonData)
+	BORDER:SkinCheckBoxes(checkboxData)
+
+	-- Position
+	BORDER:ClearAndSetPoint(_G.SpyStatsRefreshButton, "BOTTOMRIGHT", _G.SpyStatsFrame, "BOTTOMRIGHT", -12, 5)
+	BORDER:ClearAndSetPoint(_G.SpyStatsFrame_Title, "TOP", _G.SpyStatsFrame, "TOP", 0, -15)
+
+	-- Adjust sizes
+	BORDER:AdjustSize(_G.SpyStatsFilterBox,-20,-12)
+	BORDER:AdjustSize(_G.SpyStatsKosCheckbox,-4,-4)
+	BORDER:AdjustSize(_G.SpyStatsRealmCheckbox,-4,-4)
+	BORDER:AdjustSize(_G.SpyStatsWinsLosesCheckbox,-4,-4)
+	BORDER:AdjustSize(_G.SpyStatsReasonCheckbox,-4,-4)
+
+	-- Additional Things
+	-- Remove backdrop from Refresh button
 	_G.SpyStatsRefreshButton:SetBackdrop()
-	BORDER:CreateBorder(_G.SpyStatsRefreshButton, nil, nil, nil, nil, nil, false, true)
-	BORDER:CreateBorder(_G.SpyStatsTabFrameTabContentFrameScrollFrameScrollBar, nil, nil, nil, nil, nil, false, true)
+
+	-- Skin Close Button
+	S:HandleCloseButton(_G.SpyStatsFrameTopCloseButton)
+	S:HandleCloseButton(_G.Spy_MainWindow.CloseButton)
+
+	-- Skin Portait Frame
+	S:HandlePortraitFrame(_G.SpyStatsFrame)
+
+	-- Skin Alert Icon
+	_G.Spy_AlertWindow.Icon:CreateBackdrop()
+	BORDER:CreateBorder(_G.Spy_AlertWindow.Icon)
+
+	-- Hide Titlebar
+    _G.Spy_MainWindow.TitleBar:SetAlpha(0)
 end
 
 S:AddCallbackForAddon("Spy")

--- a/ElvUI_ProjectHopes/Core/Modules/Border/Addons/Spy.lua
+++ b/ElvUI_ProjectHopes/Core/Modules/Border/Addons/Spy.lua
@@ -12,9 +12,9 @@ function S:Spy()
 	local frameData = {
     	{frame = _G.Spy_MainWindow},
 		{frame = _G.Spy_AlertWindow},
-		{frame = _G.SpyStatsFrame.StatsFrame, scrollbar = _G.SpyStatsTabFrameTabContentFrameScrollFrameScrollBar},
+		{frame = _G.SpyStatsFrame.StatsFrame},
 		{frame = _G.SpyStatsPlayerHistoryFrame},
-		{frame = _G.SpyStatsTabFrameTabContentFrame},
+		{frame = _G.SpyStatsTabFrameTabContentFrame, scrollbar = _G.SpyStatsTabFrameTabContentFrameScrollFrameScrollBar},
 		{frame = _G.SpyStatsTabFrameTabContentFrame.ContentFrame},
 	}
 

--- a/ElvUI_ProjectHopes/Core/Modules/Border/Core.lua
+++ b/ElvUI_ProjectHopes/Core/Modules/Border/Core.lua
@@ -526,6 +526,17 @@ function BORDER:SkinButtonList(buttonData)
     end
 end
 
+-- Function to skin multiple checkboxes with unique parameters
+function BORDER:SkinCheckBoxes(checkboxData)
+    for _, data in ipairs(checkboxData) do
+        local checkbox = data.checkbox
+        local params = data.borderParams
+
+        -- Skin the button box
+        SkinElement(checkbox, function(checkbox) S:HandleCheckBox(checkbox) end, params)
+    end
+end
+
 -- Function to skin multiple frames with unique parameters
 function BORDER:SkinFrameList(frameData)
     for _, data in ipairs(frameData) do
@@ -548,9 +559,14 @@ function BORDER:SkinEditboxList(editboxData)
     for _, data in ipairs(editboxData) do
         local editbox = data.editbox
         local params = data.borderParams
+		local size = data.width
 
         -- Skin the editbox box
         SkinElement(editbox, function(editbox) S:HandleEditBox(editbox) end, params)
+
+		if size then
+			editbox:SetWidth(size)
+		end
     end
 end
 


### PR DESCRIPTION
Fixed the following in Spy
->Skin missed scrollbar
->Made some frames smaller to fix some overlaps (in meantime I have re-wrote this with the new functions)

Additional helper functions on Config
--> Added helper function for checkboxes